### PR TITLE
feat: run wheel instead

### DIFF
--- a/libs/hyperpocket/hyperpocket/server/tool/dto/script.py
+++ b/libs/hyperpocket/hyperpocket/server/tool/dto/script.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pydantic import BaseModel, Field
 
 from hyperpocket.tool.wasm.script import ScriptFileNode
@@ -8,8 +9,20 @@ class Script(BaseModel):
     tool_id: str = Field(alias='tool_id')
 
 
-class ScriptStdout(BaseModel):
-    stdout: str = Field(alias='stdout')
+class ScriptResult(BaseModel):
+    stdout: Optional[str] = Field(alias='stdout', default=None)
+    stderr: Optional[str] = Field(alias='stderr', default=None)
+    error: Optional[str] = Field(alias='error', default=None)
 
 class ScriptFileTree(BaseModel):
     tree: dict[str, ScriptFileNode] = Field(alias='tree')
+
+class ScriptEntrypoint(BaseModel):
+    package_name: Optional[str] = Field(alias='package_name')
+    entrypoint: str = Field(alias='entrypoint')
+
+class ScriptEncodedFile(BaseModel):
+    encoded_file: str = Field(alias='encoded_file')
+
+class ScriptFileRequest(BaseModel):
+    path: str = Field(alias='path')

--- a/libs/hyperpocket/hyperpocket/server/tool/wasm.py
+++ b/libs/hyperpocket/hyperpocket/server/tool/wasm.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, FileResponse
 
 from hyperpocket.futures import FutureStore
 from hyperpocket.server.tool.dto import script as scriptdto
@@ -17,15 +17,27 @@ async def browse_script_page(script_id: str):
 
 
 @wasm_tool_router.post("/scripts/{script_id}/done")
-async def done_script_page(script_id: str, req: scriptdto.ScriptStdout) -> scriptdto.ScriptStdout:
-    FutureStore.resolve_future(script_id, req.stdout)
-    return scriptdto.ScriptStdout(stdout=req.stdout)
-
-@wasm_tool_router.post("/scripts/{script_id}/fail")
-async def fail_script_page(script_id: str, req: scriptdto.ScriptStdout) -> scriptdto.ScriptStdout:
-    pass
+async def done_script_page(script_id: str, req: scriptdto.ScriptResult) -> scriptdto.ScriptResult:
+    FutureStore.resolve_future(script_id, {
+        'stdout': req.stdout,
+        'stderr': req.stderr,
+        'error': req.error
+    })
+    return req
 
 @wasm_tool_router.get("/scripts/{script_id}/file_tree")
 async def get_file_tree(script_id: str) -> scriptdto.ScriptFileTree:
     script = ScriptStore.get_script(script_id)
     return scriptdto.ScriptFileTree(tree=script.load_file_tree())
+
+@wasm_tool_router.get("/scripts/{script_id}/entrypoint")
+async def get_entrypoint(script_id: str) -> scriptdto.ScriptEntrypoint:
+    script = ScriptStore.get_script(script_id)
+    package_name = script.package_name
+    entrypoint = f"/tools/wasm/scripts/{script_id}/file/{script.entrypoint}"
+    return scriptdto.ScriptEntrypoint(package_name=package_name, entrypoint=entrypoint)
+
+@wasm_tool_router.get("/scripts/{script_id}/file/{file_name}", response_class=FileResponse)
+async def get_dist_file(script_id: str, file_name: str):
+    script = ScriptStore.get_script(script_id)
+    return FileResponse(script.dist_file_path(file_name))


### PR DESCRIPTION
migrated from `https://github.com/vessl-ai/tool-calling/pull/47`

main.py와 requirements.txt의 조합으로 돌리던 것 대신, whl 파일을 돌립니다.
현재 mysql-query 툴 제외 wheel 화 하지 않았으며 해야합니다.

# 의도된 사항
- dist/xxx.tar.gz, dist/xxx.whl 은 의도적으로 커밋됩니다

# 장점
- 소스코드 분할해도 상관 없다! 어차피 패키지에 말림
- 표준이다! 근본 없는 main.py 같은 건 이제 없음
- whl 파일 인스톨하면 알아서 requirements까지 말려 올라간다! requirements.txt desync 걱정은 없음

# 단점
- 조-금 더 복잡해진 연동 흐름, 그러나 파이썬 스탠다드이므로 넘어가도 충분해보이긴 함.
- dist wheel과 현재 버전이 매치하는지 보장할 방법이 없음. CI action 같은 거 천천히 줘도 될 듯?
- __init__.py에 main 함수가 export 되어야 함. boilerplate 만들 때 챙겨야 함!
