### PR TITLE
add postprocessing for tools

### DIFF
--- a/libs/hyperpocket/hyperpocket/tool/tool.py
+++ b/libs/hyperpocket/hyperpocket/tool/tool.py
@@ -1,13 +1,11 @@
 import abc
-from typing import Optional, Type, Callable, Any
+from typing import Optional, Type, Callable
 
 from pydantic import BaseModel, Field
 
 from hyperpocket.auth.provider import AuthProvider
 from hyperpocket.config.logger import pocket_logger
 from hyperpocket.util.json_schema_to_model import json_schema_to_model
-
-PostprocessFunction = Callable[[str], Any]
 
 
 class ToolAuth(BaseModel):
@@ -29,23 +27,23 @@ class ToolAuth(BaseModel):
 
 
 class ToolRequest(abc.ABC):
-    postprocessings: Optional[list[PostprocessFunction]] = None
+    postprocessings: Optional[list[Callable]] = None
 
     @abc.abstractmethod
     def __str__(self):
         raise NotImplementedError
     
-    def add_postprocessing(self, postprocessing: PostprocessFunction):
+    def add_postprocessing(self, postprocessing: Callable):
         if self.postprocessings is None:
             self.postprocessings = [postprocessing]
         else:
             self.postprocessings.append(postprocessing)
 
-    def __or__(self, other: PostprocessFunction):
+    def __or__(self, other: Callable):
         self.add_postprocessing(other)
         return self
 
-    def with_postprocessings(self, postprocessings: list[PostprocessFunction]):
+    def with_postprocessings(self, postprocessings: list[Callable]):
         if self.postprocessings is None:
             self.postprocessings = postprocessings
         else:
@@ -61,7 +59,7 @@ class Tool(BaseModel, abc.ABC):
     description: str = Field(description="tool description")
     argument_json_schema: Optional[dict] = Field(default=None, description="tool argument json schema")
     auth: Optional[ToolAuth] = Field(default=None, description="authentication information to invoke tool")
-    postprocessings: Optional[list[PostprocessFunction]] = None
+    postprocessings: Optional[list[Callable]] = None
 
     @abc.abstractmethod
     def invoke(self, **kwargs) -> str:
@@ -127,17 +125,17 @@ class Tool(BaseModel, abc.ABC):
             pocket_logger.warning(f"failed to get tool({name}) schema model. error : {e}")
             pass
 
-    def add_postprocessing(self, postprocessing: PostprocessFunction):
+    def add_postprocessing(self, postprocessing: Callable):
         if self.postprocessings is None:
             self.postprocessings = [postprocessing]
         else:
             self.postprocessings.append(postprocessing)
 
-    def __or__(self, other: PostprocessFunction):
+    def __or__(self, other: Callable):
         self.add_postprocessing(other)
         return self
 
-    def with_postprocessings(self, postprocessings: list[PostprocessFunction]):
+    def with_postprocessings(self, postprocessings: list[Callable]):
         if self.postprocessings is None:
             self.postprocessings = postprocessings
         else:


### PR DESCRIPTION
WasmTool에 postprocessing 기능을 추가합니다.

유저가 수정하기 힘든 툴(GitTool, HfSpaceTool, LangchainTool 등...)에 임의의 후처리 과정을 추가하여 유저가 원하는 동작을 수행할 수 있습니다.
- response에서 원하는 필드를 추출하여 llm의 context length 소모량 감소
- 결과값을 json이나 dict가 아닌 yaml 등의 다른 포맷으로 변경

```python
with Pocket(
    tools=[
       from_git("https://github.com/myid/myrepo", "main", "src/tool").with_postprocessings([my_postprocessing])
    ],
) as pocket:
    ...
```

function_tool은 postprocessing을 지원하지 않습니다. 코드 켜서 함수 수정하면 끝이니까요.
