### PR TITLE
Add `postprocessing` feature to `Tool`

### DIFF
--- a/libs/hyperpocket/hyperpocket/pocket_main.py
+++ b/libs/hyperpocket/hyperpocket/pocket_main.py
@@ -327,7 +327,7 @@ class Pocket(object):
             pocket_logger.warning("Timeout tool call.")
             return "timeout tool call"
 
-        if hasattr(tool, "postprocessings") and tool.postprocessings is not None:
+        if tool.postprocessings is not None:
             for postprocessing in tool.postprocessings:
                 try:
                     result = postprocessing(result)

--- a/libs/hyperpocket/hyperpocket/pocket_main.py
+++ b/libs/hyperpocket/hyperpocket/pocket_main.py
@@ -322,10 +322,23 @@ class Pocket(object):
         """
         tool = self._tool_instance(tool_name)
         try:
-            return await asyncio.wait_for(tool.ainvoke(**kwargs), timeout=180)
+            result = await asyncio.wait_for(tool.ainvoke(**kwargs), timeout=180)
         except asyncio.TimeoutError:
             pocket_logger.warning("Timeout tool call.")
             return "timeout tool call"
+
+        if hasattr(tool, "postprocessings") and tool.postprocessings is not None:
+            for postprocessing in tool.postprocessings:
+                try:
+                    result = postprocessing(result)
+                except Exception as e:
+                    exception_str = (
+                        f"Error in postprocessing `{postprocessing.__name__}`: {e}"
+                    )
+                    pocket_logger.error(exception_str)
+                    return exception_str
+
+        return result
 
     def _tool_instance(self, tool_name: str) -> Tool:
         return self.tools[tool_name]

--- a/libs/hyperpocket/hyperpocket/tool/tool.py
+++ b/libs/hyperpocket/hyperpocket/tool/tool.py
@@ -59,7 +59,7 @@ class Tool(BaseModel, abc.ABC):
     description: str = Field(description="tool description")
     argument_json_schema: Optional[dict] = Field(default=None, description="tool argument json schema")
     auth: Optional[ToolAuth] = Field(default=None, description="authentication information to invoke tool")
-    postprocessings: Optional[list[Callable]] = None
+    postprocessings: Optional[list[Callable]] = Field(default=None, description="postprocessing functions after tool is invoked")
 
     @abc.abstractmethod
     def invoke(self, **kwargs) -> str:
@@ -126,6 +126,9 @@ class Tool(BaseModel, abc.ABC):
             pass
 
     def add_postprocessing(self, postprocessing: Callable):
+        """
+        Add a postprocessing function to the tool
+        """
         if self.postprocessings is None:
             self.postprocessings = [postprocessing]
         else:
@@ -136,6 +139,10 @@ class Tool(BaseModel, abc.ABC):
         return self
 
     def with_postprocessings(self, postprocessings: list[Callable]):
+        """
+        Add a list of postprocessing functions to the tool
+        Returns the tool itself
+        """
         if self.postprocessings is None:
             self.postprocessings = postprocessings
         else:

--- a/libs/hyperpocket/hyperpocket/tool/tool.py
+++ b/libs/hyperpocket/hyperpocket/tool/tool.py
@@ -1,13 +1,11 @@
 import abc
-from typing import Optional, Type, Callable, Any
+from typing import Optional, Type, Callable
 
 from pydantic import BaseModel, Field
 
 from hyperpocket.auth.provider import AuthProvider
 from hyperpocket.config.logger import pocket_logger
 from hyperpocket.util.json_schema_to_model import json_schema_to_model
-
-PostprocessFunction = Callable[[str], Any]
 
 
 class ToolAuth(BaseModel):
@@ -29,23 +27,23 @@ class ToolAuth(BaseModel):
 
 
 class ToolRequest(abc.ABC):
-    postprocessings: Optional[list[PostprocessFunction]] = None
+    postprocessings: Optional[list[Callable]] = None
 
     @abc.abstractmethod
     def __str__(self):
         raise NotImplementedError
     
-    def add_postprocessing(self, postprocessing: PostprocessFunction):
+    def add_postprocessing(self, postprocessing: Callable):
         if self.postprocessings is None:
             self.postprocessings = [postprocessing]
         else:
             self.postprocessings.append(postprocessing)
 
-    def __or__(self, other: PostprocessFunction):
+    def __or__(self, other: Callable):
         self.add_postprocessing(other)
         return self
 
-    def with_postprocessings(self, postprocessings: list[PostprocessFunction]):
+    def with_postprocessings(self, postprocessings: list[Callable]):
         if self.postprocessings is None:
             self.postprocessings = postprocessings
         else:
@@ -61,7 +59,7 @@ class Tool(BaseModel, abc.ABC):
     description: str = Field(description="tool description")
     argument_json_schema: Optional[dict] = Field(default=None, description="tool argument json schema")
     auth: Optional[ToolAuth] = Field(default=None, description="authentication information to invoke tool")
-    postprocessings: Optional[list[PostprocessFunction]] = None
+    postprocessings: Optional[list[Callable]] = None
 
     @abc.abstractmethod
     def invoke(self, **kwargs) -> str:
@@ -127,17 +125,17 @@ class Tool(BaseModel, abc.ABC):
             pocket_logger.warning(f"failed to get tool({name}) schema model. error : {e}")
             pass
 
-    def add_postprocessing(self, postprocessing: PostprocessFunction):
+    def add_postprocessing(self, postprocessing: Callable):
         if self.postprocessings is None:
             self.postprocessings = [postprocessing]
         else:
             self.postprocessings.append(postprocessing)
 
-    def __or__(self, other: PostprocessFunction):
+    def __or__(self, other: Callable):
         self.add_postprocessing(other)
         return self
 
-    def with_postprocessings(self, postprocessings: list[PostprocessFunction]):
+    def with_postprocessings(self, postprocessings: list[Callable]):
         if self.postprocessings is None:
             self.postprocessings = postprocessings
         else:

--- a/libs/hyperpocket/hyperpocket/tool/tool.py
+++ b/libs/hyperpocket/hyperpocket/tool/tool.py
@@ -125,7 +125,7 @@ class Tool(BaseModel, abc.ABC):
             pocket_logger.warning(f"failed to get tool({name}) schema model. error : {e}")
             pass
 
-    def add_postprocessing(self, postprocessing: Callable):
+    def with_postprocessing(self, postprocessing: Callable):
         """
         Add a postprocessing function to the tool
         """
@@ -133,9 +133,10 @@ class Tool(BaseModel, abc.ABC):
             self.postprocessings = [postprocessing]
         else:
             self.postprocessings.append(postprocessing)
+        return self
 
     def __or__(self, other: Callable):
-        self.add_postprocessing(other)
+        self.with_postprocessing(other)
         return self
 
     def with_postprocessings(self, postprocessings: list[Callable]):

--- a/libs/hyperpocket/hyperpocket/tool/wasm/tool.py
+++ b/libs/hyperpocket/hyperpocket/tool/wasm/tool.py
@@ -109,6 +109,7 @@ class WasmTool(Tool):
             readme=readme,
             pkg_lock=tool_req.lock,
             rel_path=tool_req.rel_path,
+            postprocessings=tool_req.postprocessings,
         )
 
     @classmethod


### PR DESCRIPTION
Tool에 postprocessing 기능을 추가합니다.

유저가 수정하기 힘든 툴(GitTool, HfSpaceTool, LangchainTool 등...)에 임의의 후처리 과정을 추가하여 유저가 원하는 동작을 수행할 수 있습니다.

- response에서 원하는 필드를 추출하여 llm의 context length 소모량 감소
- 결과값을 json이나 dict가 아닌 yaml 등의 다른 포맷으로 변경

```python
with Pocket(
    tools=[
       from_git("https://github.com/myid/myrepo", "main", "src/tool").with_postprocessing(my_postprocessing)
    ],
) as pocket:
    ...
```

pipe 인터페이스도 지원합니다.
```python
with Pocket(
    tools=[
       from_git("https://github.com/myid/myrepo", "main", "src/tool") | my_postprocessing
    ],
) as pocket:
    ...
```

여러개를 동시에 넣을 수도 있습니다.
```python
with Pocket(
    tools=[
       from_git("https://github.com/myid/myrepo", "main", "src/tool").with_postprocessings([my_postprocessing])
    ],
) as pocket:
    ...
```

function tool도 똑같이 할 수 있습니다.
```python
@function_tool
def my_function():
    ....

with Pocket(
    tools=[
       my_function.with_postprocessings([my_postprocessing])
    ],
) as pocket:
    ...

# ...or pipelining
with Pocket(
    tools=[
       my_function | my_postprocessing
    ],
) as pocket:
    ...
```
