### PR TITLE
Change the default directory where settings files are stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ playwright install
 
 ### 2. Configuration
 
-setting hyperpocket config in `~/.pocket/`
+setting hyperpocket config in your current working directory
 
-`~/.pocket/settings.toml`
+`${WORKDIR}/settings.toml`
 
 ```toml
 log_level = "debug"
@@ -58,7 +58,7 @@ client_id = "<SLACK_CLIENT_ID>"
 client_secret = "<SLACK_CLIENT_SECRET>"
 ```
 
-`~/.pocket/.secret.toml`
+`${WORKDIR}/.secret.toml`
 
 ```toml
 OPENAI_API_KEY = "<OPENAI_API_KEY>"

--- a/libs/hyperpocket/README.md
+++ b/libs/hyperpocket/README.md
@@ -187,11 +187,7 @@ Assistance: Here are the recent 10 messages.
 
 ### Config
 
-Running `hyperpocket config init` will create your config file in `$HOME/.pocket/settings.toml`
-
 The `settings.toml` looks as follows.
-
-TODO: Add `secrets.toml`.
 
 ```toml
 log_level = "debug"

--- a/libs/hyperpocket/hyperpocket/config/settings.py
+++ b/libs/hyperpocket/hyperpocket/config/settings.py
@@ -8,28 +8,19 @@ from hyperpocket.config.auth import AuthConfig, DefaultAuthConfig
 from hyperpocket.config.session import DefaultSessionConfig, SessionConfig
 
 POCKET_ROOT = Path.home() / ".pocket"
+SETTING_ROOT = Path.cwd()
 
 
-def find_settings_path(filename: str) -> Path:
-    # check workdir first
-    workdir_settings_path = Path.cwd() / filename
-    if workdir_settings_path.exists():
-        return workdir_settings_path
-
-    # check home directory
-    pocket_root_settings_path = POCKET_ROOT / filename
-    if pocket_root_settings_path.exists():
-        return pocket_root_settings_path
-
-    # if both of them do not exist, create the path in workdir and return it
-    workdir_settings_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(workdir_settings_path, "w"):
+settings_path = SETTING_ROOT / "settings.toml"
+if not settings_path.exists():
+    with open(settings_path, "w"):
         pass
-    return workdir_settings_path
 
+secret_path = SETTING_ROOT / ".secrets.toml"
+if not secret_path.exists():
+    with open(secret_path, "w"):
+        pass
 
-settings_path = find_settings_path("settings.toml")
-secret_path = find_settings_path(".secrets.toml")
 
 toolpkg_path = POCKET_ROOT / "toolpkg"
 if not toolpkg_path.exists():


### PR DESCRIPTION
By default, setting files (`settings.toml` and `.secrets.toml`) are stored in `POCKET_ROOT` (`$HOME/.pocket`). 

This PR changes the default location to the working directory. `POCKET_ROOT` will only remains as tool package location.