### PR TITLE
Edit raise way in server

### DIFF
--- a/libs/hyperpocket/hyperpocket/server/server.py
+++ b/libs/hyperpocket/hyperpocket/server/server.py
@@ -136,11 +136,11 @@ class PocketServer(object):
         while True:
             if conn.poll():
                 op, uid, result, error = conn.recv()
-                if error:
-                    raise error
-
                 future = self.future_store[uid]
-                future.set_result(result)
+                if error:
+                    future.set_exception(error)
+                else:
+                    future.set_result(result)
                 break
             else:
                 await asyncio.sleep(0)


### PR DESCRIPTION
## Desc

- The previous approach could not capture errors because they were raised within `asyncio.Task`.
- This new approach propagates errors to the future result, allowing them to be raised by the caller.
