### PR TITLE
edit `extract_func_param_desc_from_docstring` regex and chore

### DIFF
--- a/libs/hyperpocket/hyperpocket/util/extract_func_param_desc_from_docstring.py
+++ b/libs/hyperpocket/hyperpocket/util/extract_func_param_desc_from_docstring.py
@@ -23,14 +23,12 @@ def extract_param_docstring_mapping(func) -> dict[str, str]:
     if not docstring:
         return {}
 
-    pocket_logger.debug(f"try to extract docstring of {func.__name__} by google style..")
     param_mapping = extract_param_desc_by_google_stype_docstring(docstring, func_params)
     if param_mapping:
         pocket_logger.debug(f"success extract docstring of {func.__name__} by google style!")
         return param_mapping
     pocket_logger.debug(f"not found param desc of {func.__name__} by google style..")
 
-    pocket_logger.debug(f"try to extract docstring of {func.__name__} by other style..")
     param_mapping = extract_param_desc_by_other_styles(docstring, func_params)
     if param_mapping:
         pocket_logger.debug(f"success extract docstring of {func.__name__} by other style!")
@@ -38,7 +36,6 @@ def extract_param_docstring_mapping(func) -> dict[str, str]:
     pocket_logger.debug(f"not found param desc of {func.__name__} by other styles..")
 
     # Plain Text Style matching
-    pocket_logger.debug(f"try to extract docstring of {func.__name__} by plain text style..")
     param_descriptions = []
     for line in docstring.split("\n"):
         split_line = line.strip().split(":")
@@ -46,7 +43,8 @@ def extract_param_docstring_mapping(func) -> dict[str, str]:
             continue
 
         param_name = split_line[0]
-        cleaned_param_name = clean_bracket_content(param_name)
+        cleaned_param_name = clean_string(param_name)
+        cleaned_param_name = clean_bracket_content(cleaned_param_name)
         description = ":".join(split_line[1:]).strip()
         if cleaned_param_name in func_params:
             param_descriptions.append((cleaned_param_name, description))
@@ -58,6 +56,11 @@ def extract_param_docstring_mapping(func) -> dict[str, str]:
     return param_mapping
 
 
+def clean_string(input_string):
+    cleaned = re.sub(r"^[^a-zA-Z_]*|[^a-zA-Z0-9_()\s]*$", "", input_string)
+    return cleaned.strip()
+
+
 def clean_bracket_content(content):
     return re.sub(r"[(\[{<].*?[)\]}>]", "", content)
 
@@ -65,9 +68,9 @@ def clean_bracket_content(content):
 def extract_param_desc_by_other_styles(docstring, func_params) -> dict[str, str]:
     param_descriptions = []
     # Pattern for Sphinx-style or Javadoc-style `:param`, `@param`, `:arg`, `@arg`
-    param_pattern = r"(?:@param|:param|:arg|@arg)\s+(\w+)(?:\s*:\s*|\s+|:\s+)(.*)"
-    matches = re.findall(param_pattern, docstring)
-    for param, desc in matches:
+    param_pattern = r"^\s*(?:@param|:param|:arg|@arg):?\s+(\w+)(?:\((.*?)\))?:\s*(.*)"
+    matches = re.findall(param_pattern, docstring, re.MULTILINE)
+    for param, _, desc in matches:
         cleaned_param = clean_bracket_content(param)
         param_descriptions.append((cleaned_param, desc.strip()))
     # Ensure no duplicates and match with function parameters
@@ -87,7 +90,7 @@ def extract_param_desc_by_google_stype_docstring(docstring, func_params) -> dict
     param_descriptions = {}
     for line in param_lines:
         # Match parameter line with "name (type): description"
-        param_match = re.match(r"^\s*(\w+)\s*\(\s*(.*?)\s*\)\s*:\s*(.*)", line)
+        param_match = re.match(r"^[^a-zA-Z_]*([a-zA-Z_]\w*)\s*[\(\[]\s*(.*?)\s*[\)\]]\s*:\s*(.*)", line)
         if param_match:
             param, _, desc = param_match.groups()
             cleaned_param = clean_bracket_content(param)

--- a/libs/hyperpocket/hyperpocket/util/extract_func_param_desc_from_docstring.py
+++ b/libs/hyperpocket/hyperpocket/util/extract_func_param_desc_from_docstring.py
@@ -68,7 +68,7 @@ def clean_bracket_content(content):
 def extract_param_desc_by_other_styles(docstring, func_params) -> dict[str, str]:
     param_descriptions = []
     # Pattern for Sphinx-style or Javadoc-style `:param`, `@param`, `:arg`, `@arg`
-    param_pattern = r"^\s*(?:@param|:param|:arg|@arg):?\s+(\w+)(?:\((.*?)\))?:\s*(.*)"
+    param_pattern = r"^\s*(?:@param|:param|:arg|@arg):?\s+(\w+)(?:\((.*?)\))?:?\s*(.*)"
     matches = re.findall(param_pattern, docstring, re.MULTILINE)
     for param, _, desc in matches:
         cleaned_param = clean_bracket_content(param)

--- a/libs/hyperpocket/tests/utils/test_extract_func_param_desc_from_docstring.py
+++ b/libs/hyperpocket/tests/utils/test_extract_func_param_desc_from_docstring.py
@@ -1,0 +1,188 @@
+import unittest
+
+from hyperpocket.util.extract_func_param_desc_from_docstring import extract_param_docstring_mapping
+
+
+class TestExtractFuncParamDescFromDocstring(unittest.TestCase):
+    def test_extract_google_style_param_case1(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            Args:
+                a(int): first
+                b(int): second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_google_style_param_case2(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            Args:
+                - a (int) : first
+                - b (int) : second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_google_style_param_case3(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            Args:
+                1. a (int) : first
+                2. b (int) : second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_other_style_param_case1(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            :param: a: first
+            :param: b: second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_other_style_param_case2(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            :param: a(int): first
+            :param: b(int): second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_other_style_param_case3(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            @param: a: first
+            @param: b: second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_other_style_param_case4(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            @param a(int): first
+            @param b(int): second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_other_style_param_case5(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            @arg: a: first
+            @arg: b: second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_other_style_param_case6(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            @arg a(int): first
+            @arg b(int): second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_other_style_param_case7(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            :arg: a: first
+            :arg: b: second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_other_style_param_case8(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            :arg a(int): first
+            :arg b(int): second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_plain_style_param_case1(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            a(int) : first
+            b(int) : second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_plain_style_param_case2(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            - a(int) : first
+            - b(int) : second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+
+    def test_extract_plain_style_param_case3(self):
+        def style_func(a: int, b: int):
+            """
+            a: first
+            b: second
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first', 'b': 'second'})

--- a/libs/hyperpocket/tests/utils/test_extract_func_param_desc_from_docstring.py
+++ b/libs/hyperpocket/tests/utils/test_extract_func_param_desc_from_docstring.py
@@ -10,13 +10,13 @@ class TestExtractFuncParamDescFromDocstring(unittest.TestCase):
             Style Function
 
             Args:
-                a(int): first
-                b(int): second
+                a(int): first desc
+                b(int): second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_google_style_param_case2(self):
         def style_func(a: int, b: int):
@@ -24,13 +24,13 @@ class TestExtractFuncParamDescFromDocstring(unittest.TestCase):
             Style Function
 
             Args:
-                - a (int) : first
-                - b (int) : second
+                - a (int) : first desc
+                - b (int) : second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_google_style_param_case3(self):
         def style_func(a: int, b: int):
@@ -38,151 +38,177 @@ class TestExtractFuncParamDescFromDocstring(unittest.TestCase):
             Style Function
 
             Args:
-                1. a (int) : first
-                2. b (int) : second
+                1. a (int) : first desc
+                2. b (int) : second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_other_style_param_case1(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            :param: a: first
-            :param: b: second
+            :param: a: first desc
+            :param: b: second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_other_style_param_case2(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            :param: a(int): first
-            :param: b(int): second
+            :param: a(int): first desc
+            :param: b(int): second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_other_style_param_case3(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            @param: a: first
-            @param: b: second
+            @param: a: first desc
+            @param: b: second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_other_style_param_case4(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            @param a(int): first
-            @param b(int): second
+            @param a(int): first desc
+            @param b(int): second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_other_style_param_case5(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            @arg: a: first
-            @arg: b: second
+            @arg: a: first desc
+            @arg: b: second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_other_style_param_case6(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            @arg a(int): first
-            @arg b(int): second
+            @arg a(int): first desc
+            @arg b(int): second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_other_style_param_case7(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            :arg: a: first
-            :arg: b: second
+            :arg: a: first desc
+            :arg: b: second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_other_style_param_case8(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            :arg a(int): first
-            :arg b(int): second
+            :arg a(int): first desc
+            :arg b(int): second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
+
+    def test_extract_other_style_param_case9(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            @arg a first desc
+            @arg b second desc
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
+
+    def test_extract_other_style_param_case10(self):
+        def style_func(a: int, b: int):
+            """
+            Style Function
+
+            :arg a first desc
+            :arg b second desc
+            """
+            pass
+
+        params = extract_param_docstring_mapping(style_func)
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_plain_style_param_case1(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            a(int) : first
-            b(int) : second
+            a(int) : first desc
+            b(int) : second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_plain_style_param_case2(self):
         def style_func(a: int, b: int):
             """
             Style Function
 
-            - a(int) : first
-            - b(int) : second
+            - a(int) : first desc
+            - b(int) : second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})
 
     def test_extract_plain_style_param_case3(self):
         def style_func(a: int, b: int):
             """
-            a: first
-            b: second
+            a: first desc
+            b: second desc
             """
             pass
 
         params = extract_param_docstring_mapping(style_func)
-        self.assertEqual(params, {'a': 'first', 'b': 'second'})
+        self.assertEqual(params, {'a': 'first desc', 'b': 'second desc'})


### PR DESCRIPTION
## new supported

### google style args starting with "-" or others

```python
def style_func(a: int, b: int):
    """
    Style Function

    Args:
        - a (int) : first
        - b (int) : second
    """
    pass
```


### plain style args starting with "-" or others

```python
def style_func(a: int, b: int):
    """
    - a(int) : first
    - b(int) : second
    """
    pass
```


### Sphinx and other styles

- bug fix
  - add `re.MULTILINE` flag


## Test

- [x] add test code
  - libs/hyperpocket/tests/utils/test_extract_func_param_desc_from_docstring.py