### PR TITLE
Fix langchain prompttemplate to have system prompt first

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ if __name__ == '__main__':
     llm = ChatOpenAI(model="gpt-4o", api_key=secret["OPENAI_API_KEY"])
     prompt = ChatPromptTemplate.from_messages(
         [
-            ("placeholder", "{chat_history}"),
             (
                 "system",
                 "You are a tool calling assistant. You can help the user by calling proper tools",
             ),
+            ("placeholder", "{chat_history}"),
             ("user", "{input}"),
             MessagesPlaceholder(variable_name="agent_scratchpad"),
         ]

--- a/docs/hyperpocket/managed/getting_started.md
+++ b/docs/hyperpocket/managed/getting_started.md
@@ -68,11 +68,11 @@ if __name__ == '__main__':
     llm = ChatOpenAI(model="gpt-4o", api_key=secret["OPENAI_API_KEY"])
     prompt = ChatPromptTemplate.from_messages(
         [
-            ("placeholder", "{chat_history}"),
             (
                 "system",
                 "You are a tool calling assistant. You can help the user by calling proper tools",
             ),
+            ("placeholder", "{chat_history}"),
             ("user", "{input}"),
             MessagesPlaceholder(variable_name="agent_scratchpad"),
         ]

--- a/examples/langchain/gumloop-agent/gumloop_agent/agent.py
+++ b/examples/langchain/gumloop-agent/gumloop_agent/agent.py
@@ -15,11 +15,11 @@ def agent(pocket: PocketLangchain):
 
     prompt = ChatPromptTemplate.from_messages(
         [
-            ("placeholder", "{chat_history}"),
             (
                 "system",
                 "You are a tool calling assistant. You can help the user by calling proper tools",
             ),
+            ("placeholder", "{chat_history}"),
             ("user", "{input}"),
             MessagesPlaceholder(variable_name="agent_scratchpad"),
         ]

--- a/examples/langchain/slack-bot-agent/slack_bot_agent/main.py
+++ b/examples/langchain/slack-bot-agent/slack_bot_agent/main.py
@@ -42,7 +42,6 @@ def agent_generator(pocket: PocketLangchain):
     def _agent(thread_id: str):
         prompt = ChatPromptTemplate.from_messages(
             [
-                ("placeholder", "{chat_history}"),
                 (
                     "system",
                     """
@@ -64,6 +63,7 @@ def agent_generator(pocket: PocketLangchain):
                     Otherwise, just say "N/A".
                     """,
                 ),
+                ("placeholder", "{chat_history}"),
                 ("user", "{input}"),
                 MessagesPlaceholder(variable_name="agent_scratchpad"),
             ]

--- a/examples/langchain/tool-calling-agent/agent_inject.py
+++ b/examples/langchain/tool-calling-agent/agent_inject.py
@@ -15,11 +15,11 @@ def agent(pocket: PocketLangchain):
 
     prompt = ChatPromptTemplate.from_messages(
         [
-            ("placeholder", "{chat_history}"),
             (
                 "system",
                 "You are a tool calling assistant. You can help the user by calling proper tools",
             ),
+            ("placeholder", "{chat_history}"),
             ("user", "{input}"),
             MessagesPlaceholder(variable_name="agent_scratchpad"),
         ]

--- a/examples/langchain/tool-calling-agent/tool_calling_agent/agent.py
+++ b/examples/langchain/tool-calling-agent/tool_calling_agent/agent.py
@@ -20,6 +20,7 @@ def agent(pocket: PocketLangchain):
                 "system",
                 "You are a tool calling assistant. You can help the user by calling proper tools",
             ),
+            ("placeholder", "{chat_history}"),
             ("user", "{input}"),
             MessagesPlaceholder(variable_name="agent_scratchpad"),
         ]

--- a/libs/extensions/langchain/README.md
+++ b/libs/extensions/langchain/README.md
@@ -49,12 +49,11 @@ tools = pocket.get_tools()
 llm = ChatOpenAI()
 
 prompt = ChatPromptTemplate.from_messages(
-    [
-        ("placeholder", "{chat_history}"),
         (
             "system",
             "You are very powerful linear assistant. You can help the user do something like commenting, get some issues",
         ),
+        ("placeholder", "{chat_history}"),
         ("user", "{input}"),
         MessagesPlaceholder(variable_name="agent_scratchpad"),
     ]


### PR DESCRIPTION
When you use mistral-large for LLM engine with Langchain, if system message is after the chat histories in ChatPromptTemplate, LLM returns error.