### PR TITLE
Refactor: `PocketCore.__init__`

### DIFF
--- a/libs/hyperpocket/hyperpocket/pocket_core.py
+++ b/libs/hyperpocket/hyperpocket/pocket_core.py
@@ -276,21 +276,7 @@ class PocketCore:
     @classmethod
     def _parse_tool_like(cls, tool_like: ToolLike) -> ToolLike:
         if isinstance(tool_like, str):
-            if pathlib.Path(tool_like).exists():
-                lock = LocalLock(tool_like)
-                parsed_tool_like = WasmToolRequest(lock=lock, rel_path="", tool_vars={})
-            elif tool_like.startswith("https://github.com"):
-                base_repo_url, git_ref, rel_path = GitLock.parse_repo_url(
-                    repo_url=tool_like
-                )
-                lock = GitLock(repository_url=base_repo_url, git_ref=git_ref)
-                parsed_tool_like = WasmToolRequest(lock=lock, rel_path=rel_path, tool_vars={})
-            else:
-                parsed_tool_like = None
-                RuntimeError(
-                    f"Can't convert to ToolRequest. it might be wrong github url or local path. path: {tool_like}")
-
-            return parsed_tool_like
+            return cls._parse_str_tool_like(tool_like)
 
         elif isinstance(tool_like, WasmToolRequest):
             return tool_like
@@ -301,3 +287,22 @@ class PocketCore:
             raise ValueError("WasmTool should pass ToolRequest instance instead.")
         else:  # Callable, Tool
             return tool_like
+
+    @classmethod
+    def _parse_str_tool_like(cls, tool_like: str) -> ToolLike:
+        if pathlib.Path(tool_like).exists():
+            lock = LocalLock(tool_like)
+            parsed_tool_like = WasmToolRequest(lock=lock, rel_path="", tool_vars={})
+        elif tool_like.startswith("https://github.com"):
+            base_repo_url, git_ref, rel_path = GitLock.parse_repo_url(
+                repo_url=tool_like
+            )
+            lock = GitLock(repository_url=base_repo_url, git_ref=git_ref)
+            parsed_tool_like = WasmToolRequest(lock=lock, rel_path=rel_path, tool_vars={})
+        else:
+            parsed_tool_like = None
+            RuntimeError(
+                f"Can't convert to ToolRequest. it might be wrong github url or local path. path: {tool_like}")
+
+        return parsed_tool_like
+

--- a/libs/hyperpocket/hyperpocket/pocket_core.py
+++ b/libs/hyperpocket/hyperpocket/pocket_core.py
@@ -17,6 +17,7 @@ from hyperpocket.tool_like import ToolLike
 class PocketCore:
     auth: PocketAuth
     tools: dict[str, Tool]
+    lockfile: Lockfile
 
     def __init__(
         self,
@@ -29,48 +30,30 @@ class PocketCore:
             auth = PocketAuth()
         self.auth = auth
 
+        # init lockfile
         if lockfile_path is None:
             lockfile_path = "./pocket.lock"
         lockfile_pathlib_path = pathlib.Path(lockfile_path)
-        lockfile = Lockfile(lockfile_pathlib_path)
+        self.lockfile = Lockfile(lockfile_pathlib_path)
+
+        # parse tool_likes and add lock of the tool like to the lockfile
         tool_likes = []
         for tool_like in tools:
-            if isinstance(tool_like, str):
-                if pathlib.Path(tool_like).exists():
-                    lock = LocalLock(tool_like)
-                    req = WasmToolRequest(lock, "")
-                elif tool_like.startswith("https://github.com"):
-                    base_repo_url, git_ref, rel_path = GitLock.parse_repo_url(
-                        repo_url=tool_like
-                    )
-                    lock = GitLock(repository_url=base_repo_url, git_ref=git_ref)
-                    req = WasmToolRequest(lock=lock, rel_path=rel_path, tool_vars={})
+            parsed_tool_like = self._parse_tool_like(tool_like)
+            tool_likes.append(parsed_tool_like)
+            self._add_tool_like_lock_to_lockfile(parsed_tool_like)
+        self.lockfile.sync(force_update=force_update, referenced_only=True)
 
-                lockfile.add_lock(lock)
-                tool_likes.append(req)
-            elif isinstance(tool_like, WasmToolRequest):
-                lockfile.add_lock(tool_like.lock)
-                tool_likes.append(tool_like)
-            elif isinstance(tool_like, ToolRequest):
-                raise ValueError(f"unreachable. tool_like:{tool_like}")
-            elif isinstance(tool_like, WasmTool):
-                raise ValueError("WasmTool should pass ToolRequest instance instead.")
-            else:
-                tool_likes.append(tool_like)
-        lockfile.sync(force_update=force_update, referenced_only=True)
-
+        # load tool from tool_like
         self.tools = dict()
         for tool_like in tool_likes:
-            tool = self._load_tool(tool_like, lockfile)
-            if tool.name in self.tools:
-                pocket_logger.error(f"Duplicate tool name: {tool.name}.")
-                raise ValueError(f"Duplicate tool name: {tool.name}")
-            self.tools[tool.name] = tool
+            self._load_tool(tool_like)
 
         pocket_logger.info(
             f"All Registered Tools Loaded successfully. total registered tools : {len(self.tools)}"
         )
 
+        # load builtin tool
         builtin_tools = get_builtin_tools(self.auth)
         for tool in builtin_tools:
             self.tools[tool.name] = tool
@@ -266,17 +249,55 @@ class PocketCore:
     def _tool_instance(self, tool_name: str) -> Tool:
         return self.tools[tool_name]
 
-    @staticmethod
-    def _load_tool(tool_like: ToolLike, lockfile: Lockfile) -> Tool:
+    def _load_tool(self, tool_like: ToolLike) -> Tool:
         pocket_logger.info(f"Loading Tool {tool_like}")
         if isinstance(tool_like, Tool):
             tool = tool_like
         elif isinstance(tool_like, ToolRequest):
-            tool = Tool.from_tool_request(tool_like, lockfile=lockfile)
+            tool = Tool.from_tool_request(tool_like, lockfile=self.lockfile)
         elif isinstance(tool_like, Callable):
             tool = from_func(tool_like)
         else:
             raise ValueError(f"Invalid tool type: {type(tool_like)}")
 
+        if tool.name in self.tools:
+            pocket_logger.error(f"Duplicate tool name: {tool.name}.")
+            raise ValueError(f"Duplicate tool name: {tool.name}")
+        self.tools[tool.name] = tool
+
         pocket_logger.info(f"Complete Loading Tool {tool.name}")
         return tool
+
+    def _add_tool_like_lock_to_lockfile(self, tool_like: ToolLike):
+        if isinstance(tool_like, WasmToolRequest):  # lock is only in WasmToolRequest
+            self.lockfile.add_lock(tool_like.lock)
+        return
+
+    @classmethod
+    def _parse_tool_like(cls, tool_like: ToolLike) -> ToolLike:
+        if isinstance(tool_like, str):
+            if pathlib.Path(tool_like).exists():
+                lock = LocalLock(tool_like)
+                parsed_tool_like = WasmToolRequest(lock=lock, rel_path="", tool_vars={})
+            elif tool_like.startswith("https://github.com"):
+                base_repo_url, git_ref, rel_path = GitLock.parse_repo_url(
+                    repo_url=tool_like
+                )
+                lock = GitLock(repository_url=base_repo_url, git_ref=git_ref)
+                parsed_tool_like = WasmToolRequest(lock=lock, rel_path=rel_path, tool_vars={})
+            else:
+                parsed_tool_like = None
+                RuntimeError(
+                    f"Can't convert to ToolRequest. it might be wrong github url or local path. path: {tool_like}")
+
+            return parsed_tool_like
+
+        elif isinstance(tool_like, WasmToolRequest):
+            return tool_like
+
+        elif isinstance(tool_like, ToolRequest):
+            raise ValueError(f"unreachable. tool_like:{tool_like}")
+        elif isinstance(tool_like, WasmTool):
+            raise ValueError("WasmTool should pass ToolRequest instance instead.")
+        else:  # Callable, Tool
+            return tool_like

--- a/libs/hyperpocket/hyperpocket/pocket_main.py
+++ b/libs/hyperpocket/hyperpocket/pocket_main.py
@@ -1,5 +1,4 @@
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List, Optional, Union
 
 from hyperpocket.config import pocket_logger
@@ -90,6 +89,7 @@ class Pocket(object):
             *args,
             **kwargs,
         )
+        pocket_logger.debug(f"{tool_name} result: {result}")
         return result
 
     def invoke_with_state(

--- a/libs/hyperpocket/tests/test_pocket_core.py
+++ b/libs/hyperpocket/tests/test_pocket_core.py
@@ -1,0 +1,101 @@
+import os
+import pathlib
+import shutil
+from typing import Callable
+from unittest import IsolatedAsyncioTestCase
+
+from hyperpocket.pocket_core import PocketCore
+from hyperpocket.repository.lock import LocalLock, GitLock
+from hyperpocket.tool import from_func, Tool
+from hyperpocket.tool.wasm.tool import WasmToolRequest
+
+
+class TestPocketCore(IsolatedAsyncioTestCase):
+
+    def test_parse_local_path_tool_like(self):
+        # given
+        test_local_path = pathlib.Path(os.getcwd()) / "test_local_path"
+        if not test_local_path.exists():
+            test_local_path.mkdir()
+
+        try:
+            # when
+            parsed_tool_like = PocketCore._parse_str_tool_like(str(test_local_path))
+
+            # then
+            self.assertIsInstance(parsed_tool_like, WasmToolRequest)
+            self.assertIsInstance(parsed_tool_like.lock, LocalLock)
+            self.assertEqual(parsed_tool_like.lock.tool_path, str(test_local_path))
+
+        finally:
+            shutil.rmtree(test_local_path)
+
+    def test_parse_main_github_url_tool_like(self):
+        # given
+        test_github_url = "https://github.com/vessl-ai/hyperpocket"
+
+        # when
+        parsed_tool_like = PocketCore._parse_str_tool_like(test_github_url)
+
+        # then
+        self.assertIsInstance(parsed_tool_like, WasmToolRequest)
+        self.assertEqual(parsed_tool_like.rel_path, "")
+        self.assertIsInstance(parsed_tool_like.lock, GitLock)
+        self.assertEqual(parsed_tool_like.lock.repository_url, "https://github.com/vessl-ai/hyperpocket")
+        self.assertEqual(parsed_tool_like.lock.git_ref, "HEAD")
+
+    def test_parse_specific_github_url_tool_like(self):
+        # given
+        test_github_url = "https://github.com/vessl-ai/hyperpocket/tree/main/tools/slack/get-message"
+
+        # when
+        parsed_tool_like = PocketCore._parse_str_tool_like(test_github_url)
+
+        # then
+        self.assertIsInstance(parsed_tool_like, WasmToolRequest)
+        self.assertEqual(parsed_tool_like.rel_path, "tools/slack/get-message")
+        self.assertIsInstance(parsed_tool_like.lock, GitLock)
+        self.assertEqual(parsed_tool_like.lock.repository_url, "https://github.com/vessl-ai/hyperpocket")
+        self.assertEqual(parsed_tool_like.lock.git_ref, "main")
+
+    def test_parse_wasm_tool_like(self):
+        # given
+        local_path = pathlib.Path(os.getcwd()) / "test_local_path"
+        tool_request = WasmToolRequest(
+            LocalLock(str(local_path)),
+            rel_path="/rel/path",
+            tool_vars={}
+        )
+
+        # when
+        parsed_tool_like = PocketCore._parse_tool_like(tool_request)
+
+        # then
+        self.assertIsInstance(parsed_tool_like, WasmToolRequest)
+        self.assertEqual(parsed_tool_like.rel_path, "/rel/path")
+        self.assertIsInstance(parsed_tool_like.lock, LocalLock)
+        self.assertEqual(parsed_tool_like.lock.tool_path, str(local_path))
+
+    def test_parse_callable_tool_like(self):
+        # given
+        def call():
+            pass
+
+        # when
+        parsed_tool_like = PocketCore._parse_tool_like(call)
+
+        # then
+        self.assertIsInstance(parsed_tool_like, Callable)
+
+    def test_parse_tool(self):
+        # given
+        def call():
+            pass
+
+        tool = from_func(call)
+
+        # when
+        parsed_tool_like = PocketCore._parse_tool_like(tool)
+
+        # then
+        self.assertIsInstance(parsed_tool_like, Tool)


### PR DESCRIPTION
## Desc

refactoring `PocketCore.__init__` to reduce code complexibility

## Tasks
- [x] make `lockfile` as class member variable.
- [x] extract `_parse_tool_like` method from `__init__`
- [x] extract `_parse_str_tool_like` method from `__init__`
  - [x] fix omitted `tool_vars` arg in local path tool request parsing
    - https://github.com/vessl-ai/hyperpocket/compare/moon/refactor/pocket-core-init?expand=1#diff-738f52a90787fa3ccbf2dbc4a499eb42e83116f7301a4b47a8fa85edc781fb36R295
- [x] extract ` _add_tool_like_lock_to_lockfile` from `__init__`
- [x] move a logic that add tool to `self.tools` into `_load_tool`


## Tests
- [x] parsing local path to tool_like
- [x] parsing github main path to tool_like
- [x] parsing github arbitrary path to tool_like
- [x] parsing WasmToolRequest to tool_like
- [x] parsing Tool to tool_like
- [x] parsing Callable to tool_like